### PR TITLE
Add MongoDB Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,14 @@ CONNECTORS:
         username': MONGO_USER,
         password': MONGO_PASSWD
 ~~~
+
+## EtcdConnector
+
+~~~
+
+BACKEND: EtcdConnector
+CONNECTORS:
+    EtcdConnector:
+        host: ETCD_HOST
+        port': 2379
+~~~

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Secret Service supports multiple backend.
 - AWSSecretManager
 - Vault
 - Consul
+- etcd
+- MongoDB
 
 
 # Examples
@@ -44,3 +46,15 @@ spaceone-consul-server   ClusterIP   None             <none>        8500/TCP,830
 ...
 ~~~
 
+## MongoDBConnector
+
+~~~
+
+BACKEND: MongoDBConnector
+CONNECTORS:
+    MongoDBConnector:
+        host: MONGO_HOST
+        port': 27017,
+        username': MONGO_USER,
+        password': MONGO_PASSWD
+~~~

--- a/src/spaceone/secret/conf/global_conf.py
+++ b/src/spaceone/secret/conf/global_conf.py
@@ -40,7 +40,13 @@ CONNECTORS = {
     'EtcdConnector': {
         'host': 'localhost',
         'port': 2379
-    }
+    },
+    'MongoDBConnector': {
+        'host': 'localhost',
+        'port': 27017,
+        'username': '',
+        'password': ''
+    },
 }
 
 ENDPOINTS = {}

--- a/src/spaceone/secret/connector/__init__.py
+++ b/src/spaceone/secret/connector/__init__.py
@@ -2,3 +2,4 @@ from spaceone.secret.connector.aws_secret_manager_connector import *
 from spaceone.secret.connector.vault_connector import *
 from spaceone.secret.connector.consul_connector import *
 from spaceone.secret.connector.identity_connector import *
+from spaceone.secret.connector.mongodb_connector import *

--- a/src/spaceone/secret/connector/mongodb_connector.py
+++ b/src/spaceone/secret/connector/mongodb_connector.py
@@ -1,0 +1,32 @@
+import logging
+from pymongo import MongoClient
+from spaceone.core.connector import BaseConnector
+
+
+__all__ = ['MongoDBConnector']
+_LOGGER = logging.getLogger(__name__)
+
+
+class MongoDBConnector(BaseConnector):
+
+    def __init__(self, transaction, config):
+        super().__init__(transaction, config)
+        client = MongoClient(**config)
+        db = client.secret_data
+        self.secret_data = db.secret_data
+
+    def create_secret(self, secret_id, data):
+        _document = {'secret_id': secret_id, 'data': data}
+        return self.secret_data.insert_one(_document)
+
+    def delete_secret(self, secret_id):
+        self.secret_data.delete_one({'secret_id': secret_id})
+
+    def update_secret(self, secret_id, data):
+        _query = {'secret_id': secret_id}
+        self.secret_data.update_one(_query, {'$set': {'data': data}})
+
+    def get_secret(self, secret_id):
+        secret_data_vo = self.secret_data.find_one({'secret_id': secret_id})
+        return secret_data_vo
+

--- a/test/connector/mongodb_connector.py
+++ b/test/connector/mongodb_connector.py
@@ -29,7 +29,7 @@ class TestMongoDBConnector(unittest.TestCase):
 
     def tearDown(self, *args) -> None:
         print('(tearDown) ==> Delete data')
-        # self.test_delete_secret()
+        self.test_delete_secret()
 
     def test_create_secret(self, *args):
         # print(self.secret_id)
@@ -38,7 +38,8 @@ class TestMongoDBConnector(unittest.TestCase):
         self.mongo_connector.create_secret(self.secret_id, data)
 
     def test_update_secret(self, *args):
-        data = {'xxx': 'yyy'}
+        self.test_create_secret()
+        data = {'xxxxxxxx': 'yyyyyyyyyy'}
         self.mongo_connector.update_secret(self.secret_id, data)
 
     def test_delete_secret(self, *args):
@@ -46,8 +47,8 @@ class TestMongoDBConnector(unittest.TestCase):
 
     def test_get_secret(self, *args):
         self.test_create_secret()
-        self.mongo_connector.get_secret(self.secret_id)
-
+        result = self.mongo_connector.get_secret(self.secret_id)
+        print(result)
 
 if __name__ == "__main__":
     unittest.main(testRunner=RichTestRunner)

--- a/test/connector/mongodb_connector.py
+++ b/test/connector/mongodb_connector.py
@@ -3,24 +3,24 @@ from spaceone.core.unittest.runner import RichTestRunner
 from spaceone.core import config
 from spaceone.core import utils
 from spaceone.core.transaction import Transaction
-from spaceone.secret.connector.etcd_connector import EtcdConnector
+from spaceone.secret.connector.mongodb_connector import MongoDBConnector
 
 
-class TestEtcdConnector(unittest.TestCase):
+class TestMongoDBConnector(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
         config.init_conf(package='spaceone.secret')
         config.set_service_config()
-        config.set_global(MOCK_MODE=True)
-        connector_conf = config.get_global('CONNECTORS').get('EtcdConnector')
+        config.set_global()
+        connector_conf = config.get_global('CONNECTORS').get('MongoDBConnector')
 
         cls.secret_id = utils.generate_id('secret')
         cls.transaction = Transaction({
             'service': 'secret',
             'api_class': 'Secret'
         })
-        cls.etcd_connector = EtcdConnector(cls.transaction, connector_conf)
+        cls.mongo_connector = MongoDBConnector(cls.transaction, connector_conf)
         super().setUpClass()
 
     @classmethod
@@ -29,24 +29,24 @@ class TestEtcdConnector(unittest.TestCase):
 
     def tearDown(self, *args) -> None:
         print('(tearDown) ==> Delete data')
-        self.test_delete_secret()
+        # self.test_delete_secret()
 
     def test_create_secret(self, *args):
-        print(self.secret_id)
+        # print(self.secret_id)
         data = {'test': utils.random_string()}
 
-        self.etcd_connector.create_secret(self.secret_id, data)
+        self.mongo_connector.create_secret(self.secret_id, data)
 
     def test_update_secret(self, *args):
         data = {'xxx': 'yyy'}
-        self.etcd_connector.update_secret(self.secret_id, data)
+        self.mongo_connector.update_secret(self.secret_id, data)
 
     def test_delete_secret(self, *args):
-        self.etcd_connector.delete_secret(self.secret_id)
+        self.mongo_connector.delete_secret(self.secret_id)
 
     def test_get_secret(self, *args):
         self.test_create_secret()
-        self.etcd_connector.get_secret(self.secret_id)
+        self.mongo_connector.get_secret(self.secret_id)
 
 
 if __name__ == "__main__":

--- a/test/service/secret_service.py
+++ b/test/service/secret_service.py
@@ -13,6 +13,7 @@ from spaceone.secret.service.secret_service import SecretService
 from spaceone.secret.model.secret_model import Secret
 
 from spaceone.secret.connector.aws_secret_manager_connector import AWSSecretManagerConnector
+from spaceone.secret.connector.mongodb_connector import MongoDBConnector
 
 from spaceone.secret.info.secret_info import *
 from spaceone.secret.info.common_info import StatisticsInfo
@@ -48,8 +49,8 @@ class TestSecretService(unittest.TestCase):
         secret_vos.delete()
 
     @patch.object(MongoModel, 'connect', return_value=None)
-    @patch.object(AWSSecretManagerConnector, '__init__', return_value=None)
-    @patch.object(AWSSecretManagerConnector, 'create_secret', return_value={'secret_id': 'secret-xyz', 'name': 'Secret'})
+    @patch.object(MongoDBConnector, '__init__', return_value=None)
+    @patch.object(MongoDBConnector, 'create_secret', return_value={'secret_id': 'secret-xyz', 'name': 'Secret'})
     def test_create_secret(self, *args):
         name = utils.random_string()
 


### PR DESCRIPTION
### Category
- [x] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
According to this [suggestion](https://github.com/cloudforet-io/community/discussions/69), new Connector that can use MongoDB as a backend storage for secret data has been integrated.

The MongoDB Connector was implemented using [pymongo](https://pymongo.readthedocs.io/en/stable/index.html).
Cloudforet is using the [spaceone-core](https://github.com/cloudforet-io/python-core) framework for database processing, which was implemented using `mongoengine` and `pymongo`.

Therefore, since the `pymongo` package is already installed for this, so no additional installation is required.


### Related issue
* https://github.com/cloudforet-io/secret/issues/16