### PR TITLE
Modify response for get_secret in MongoDBConnector

### DIFF
--- a/src/spaceone/secret/connector/mongodb_connector.py
+++ b/src/spaceone/secret/connector/mongodb_connector.py
@@ -27,6 +27,7 @@ class MongoDBConnector(BaseConnector):
         self.secret_data.update_one(_query, {'$set': {'data': data}})
 
     def get_secret(self, secret_id):
-        secret_data_vo = self.secret_data.find_one({'secret_id': secret_id})
-        return secret_data_vo
+        secret_data_info = self.secret_data.find_one({'secret_id': secret_id})
+        return secret_data_info.get('data', {})
+
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
In the case of get_secret(), `secret_id` and `data` are stored together, so only `data` is returned.

### Related issue
* https://github.com/cloudforet-io/secret/issues/16
